### PR TITLE
Fix labels in release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,10 +29,10 @@ categories:
       - 'area/tests'
   - title: 📖 Documentation
     labels:
-      - rea/docs
+      - 'area/docs'
   - title: 🔒 Security
     labels:
-      - ecurity  
+      - 'security'  
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## What's New


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes label formatting issues in #44 

Corrected typos in Release Drafter labels:
- rea/docs corrected to 'area/docs'
- ecurity corrected to 'security'

This change align with the intended labels from the previously merged PR.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
