### PR TITLE
[chore] Update Go version to 1.25 and align GitHub Actions

### DIFF
--- a/.github/workflows/build-and-preview-site.yml
+++ b/.github/workflows/build-and-preview-site.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Zip Site
         run: bash docs/script.sh
       - name: Upload files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: site-dir
           path: ./site-dir.zip

--- a/.github/workflows/build-and-release-dde.yml
+++ b/.github/workflows/build-and-release-dde.yml
@@ -67,7 +67,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: meshery/docker-extension-meshery
           flavor: |
@@ -79,12 +79,12 @@ jobs:
             type=raw,value=${{env.RELEASE_CHANNEL}}-latest
             type=raw,value=${{env.RELEASE_CHANNEL}}-${{env.GIT_VERSION}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:install/docker-extension"
           push: true

--- a/.github/workflows/build-and-release-edge.yml
+++ b/.github/workflows/build-and-release-edge.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'meshery/meshery'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check if handlers were modified
         uses: dorny/paths-filter@v3
         id: changes
@@ -46,7 +46,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs
           commit_user_name: l5io
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch }}
@@ -88,7 +88,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs
           commit_user_name: l5io
@@ -108,12 +108,12 @@ jobs:
         run: |
           echo "LATEST_TAG=$(curl --silent "https://api.github.com/repos/meshery/meshery/releases" | jq ' .[] | ."tag_name"' | sed -n 1p$'\n' | tr -d '"')" >> $GITHUB_ENV
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch }} 
       - name: Docker login
-        uses: azure/docker-login@v1
+        uses: azure/docker-login@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-and-release-stable.yml
+++ b/.github/workflows/build-and-release-stable.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'meshery/meshery'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check if handlers were modified
         uses: dorny/paths-filter@v3
         id: changes
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Check if schema was modified
@@ -64,7 +64,7 @@ jobs:
               - added|modified: 'server/internal/graphql/schema/schema.graphql'
       - name: Set up Ruby
         if: steps.filter.outputs.modified == 'true'
-        uses: ruby/setup-ruby@v1.162.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.2
           bundler-cache: true
@@ -78,7 +78,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs
           commit_user_name: l5io
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Login to DockerHub
@@ -132,7 +132,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
@@ -212,7 +212,7 @@ jobs:
           echo "${{ env.EMAIL_BODY }}"
       - name: Send Email Notification
         if: env.EMAIL_BODY != ''
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@v6
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/build-ui-and-server.yml
+++ b/.github/workflows/build-ui-and-server.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - name: Build Meshery Server
         env:
           PROVIDER_BASE_URLS: http://localhost:9876
@@ -45,15 +45,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
       - name: Cache node modules
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/cache
@@ -89,13 +89,13 @@ jobs:
         run: |
           make ui-provider-build
       - name: Upload meshery-ui artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: meshery-ui
           retention-days: 30
           path: /home/runner/work/meshery/meshery/ui/out
       - name: Upload provider-ui artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: provider-ui
           retention-days: 30
@@ -109,11 +109,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6                                                          
         with:
           fetch-depth: 0
       - name: Check out meshery-istio code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: layer5io/meshery-istio
           path: ./meshery-istio
@@ -123,13 +123,13 @@ jobs:
       #     repository: layer5io/meshery-consul
       #     path: ./meshery-consul
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1
         with:
           cluster_name: "kind-cluster"
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - name: Run meshery-istio
         run: |
           mkdir -p /home/runner/.meshery/bin
@@ -143,12 +143,12 @@ jobs:
       #     go run main.go &
       #     sleep 60
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
       - name: Restore node modules cache
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/cache
@@ -162,12 +162,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Download meshery-ui artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: meshery-ui
           path: /home/runner/work/meshery/meshery/ui/out
       - name: Download provider-ui artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: provider-ui
           path: /home/runner/work/meshery/meshery/provider-ui/out
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Docker edge build & tag
@@ -230,7 +230,7 @@ jobs:
           docker push ${{ secrets.IMAGE_NAME }}:edge-${GITHUB_SHA::8}
       - name: Docker Hub Description
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -241,7 +241,7 @@ jobs:
     name: swagger-docs
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check if handlers were modified
         uses: dorny/paths-filter@v3
         id: changes
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Check if schema was modified

--- a/.github/workflows/build-ui-server-reusable-workflow.yml
+++ b/.github/workflows/build-ui-server-reusable-workflow.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - name: Setup Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -31,7 +31,7 @@ jobs:
       - run: |
           GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go build -tags draft ./server/cmd/main.go ./server/cmd/error.go
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: meshery
           path: ./main
@@ -44,12 +44,12 @@ jobs:
         with:
           repository: meshery/meshery
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
       - name: Cache node modules
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/cache
@@ -74,12 +74,12 @@ jobs:
         run: |
           make ui-provider-build
       - name: upload meshery-ui artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: meshery-ui-build
           path: ui/out/
       - name: upload Meshery-provider-ui artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: meshery-provider-ui build
           path: provider-ui/out/

--- a/.github/workflows/cncf-staging-playground-deploy-meshery.yaml
+++ b/.github/workflows/cncf-staging-playground-deploy-meshery.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest 
         steps:
         - name: Upgrade Meshery Helm Release
-          uses: appleboy/ssh-action@v1.0.3
+          uses: appleboy/ssh-action@v1
           with:
               host: ${{ secrets.METAL_SERVER3 }}
               username: root

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/discussions-data-files-update.yml
+++ b/.github/workflows/discussions-data-files-update.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'meshery/meshery'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Fetch data for mesheryctl tag
@@ -23,7 +23,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs/_data/discuss/*.json
           commit_user_name: Discussions bot

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.21"
+          go-version: "1.25"
 
       - name: Build Error Utility
         run: |
@@ -62,7 +62,7 @@ jobs:
 
       - name: Commit changes
         if: ${{ github.event_name != 'pull_request' }}  # Skip for pull requests
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: mesheryctl/helpers server/helpers/ **.go docs/
           commit_user_name: l5io

--- a/.github/workflows/eslint-gh.yml
+++ b/.github/workflows/eslint-gh.yml
@@ -5,7 +5,7 @@ jobs:
     name: runner / eslint
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run ESLint Meshery-UI
       run: cd ui && npm i eslint && npx eslint .
     - name: Run ESLint Provider-UI

--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -15,7 +15,7 @@ jobs:
       (github.event.pull_request.author_association != 'OWNER')
     steps:
       - name: Leave Welcome Comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -35,7 +35,7 @@ jobs:
               body: message
             });
       - name: Label Pull Request (Optional)
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.59
+          version: v2.7
           args: --config=.golangci.yml --timeout=10m
   unit-tests:
     name: Unit tests

--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -21,18 +21,18 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [1.21]
+        go: [1.25]
         os: [ubuntu-22.04]
     name: golangci-lint
     if: github.repository == 'meshery/meshery'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v1.59
           args: --config=.golangci.yml --timeout=10m
@@ -41,20 +41,20 @@ jobs:
     runs-on: ubuntu-22.04
     needs: golangci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Install lynx for xdg-open support
         run: sudo apt-get install lynx
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - name: Run coverage
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
         if: github.repository == 'meshery/meshery'
-        uses: codecov/codecov-action@v4.3.0
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.txt
           flags: unittests
@@ -63,13 +63,13 @@ jobs:
     runs-on: ubuntu-22.04
     needs: golangci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Install lynx for xdg-open support
         run: sudo apt-get install lynx
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.21"
       - name: Install Docker Compose
@@ -77,9 +77,9 @@ jobs:
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3 
+        uses: docker/setup-buildx-action@v36
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1
         with:
           cluster_name: "kind-cluster"
       - name: Run coverage
@@ -104,7 +104,7 @@ jobs:
           
       - name: Upload coverage to Codecov
         if: github.repository == 'meshery/meshery'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.txt
           flags: gointegrationtests     

--- a/.github/workflows/graphql.yml
+++ b/.github/workflows/graphql.yml
@@ -32,7 +32,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs/
           commit_user_name: l5io

--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{github.event_name == 'pull_request'}}
     steps:
     - uses: actions/checkout@master
-    - uses: azure/setup-helm@v3.5
+    - uses: azure/setup-helm@v4
       with:
         version: 'v3.6.0' # default is latest stable
       id: install

--- a/.github/workflows/integrations-updater.yml
+++ b/.github/workflows/integrations-updater.yml
@@ -61,7 +61,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes to Meshery.io repo
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_user_name: l5io
           repository: ./meshery.io
@@ -80,7 +80,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes to Layer5.io repo
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_user_name: l5io
           repository: ./layer5
@@ -99,7 +99,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes to Meshery repo
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_user_name: l5io
           repository: ./meshery
@@ -118,7 +118,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes to Cloud repo
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_user_name: l5io
           repository: ./meshery-cloud
@@ -130,7 +130,7 @@ jobs:
 
       - name: Send Email on Model Publish Failure
         if: failure()
-        uses: dawidd6/action-send-mail@v3.7.1
+        uses: dawidd6/action-send-mail@v6
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/invitations.yml
+++ b/.github/workflows/invitations.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Invite on label
-        uses: vj-abigo/invite-on-label@v1.2
+        uses: vj-abigo/invite-on-label@v1
         with:
           organization: layer5io
           label: issue/invite
@@ -19,7 +19,7 @@ jobs:
           INVITE_TOKEN: ${{ secrets.RELEASEDRAFTER_PAT }}
 
       - name: View context attributes
-        uses: actions/github-script@v4
+        uses: actions/github-script@v8
         id: set-url
         with:
           script: |

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -25,5 +25,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Label Commenter
-        uses: peaceiris/actions-label-commenter@v1.10.0
+        uses: peaceiris/actions-label-commenter@v1
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         

--- a/.github/workflows/mesheryctl-ci.yml
+++ b/.github/workflows/mesheryctl-ci.yml
@@ -23,12 +23,12 @@ jobs:
     if: github.repository == 'meshery/meshery'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v1.59
           working-directory: mesheryctl
@@ -41,22 +41,22 @@ jobs:
     needs: [golangci]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - name: Setup Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: goreleaser WITHOUT tag
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         if: success() && startsWith(github.ref, 'refs/tags/') == false
         env:
           RELEASE_CHANNEL: "edge"
@@ -76,14 +76,14 @@ jobs:
           if [ "${{github.event_name }}" == "release" ];then
             echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: meshery/meshery
           token: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: "1.25"
           check-latest: "true"
       - name: Run script 📜
         run: |
@@ -94,7 +94,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit ✅
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs
           commit_user_name: l5io

--- a/.github/workflows/mesheryctl-ci.yml
+++ b/.github/workflows/mesheryctl-ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.59
+          version: v2.7
           working-directory: mesheryctl
           args: --timeout 10m --verbose
           skip-cache: true

--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -30,7 +30,7 @@ jobs:
         platform: ['docker', 'kubernetes']
     steps:
       - name: Setup Kubernetes
-        uses: manusa/actions-setup-minikube@v2.11.0
+        uses: manusa/actions-setup-minikube@v2
         with:
           minikube version: 'v1.34.0'
           kubernetes version: ${{ matrix.k8s_version }}
@@ -84,7 +84,7 @@ jobs:
         platform: ['docker', 'kubernetes']
     steps:
       - name: Setup Kubernetes
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2
         with:
           minikube version: 'v1.32.0'
           kubernetes version: ${{ matrix.k8s_version }}

--- a/.github/workflows/meshmap.yml
+++ b/.github/workflows/meshmap.yml
@@ -31,8 +31,8 @@ jobs:
         run: |
           export pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           echo "PULL_NO=$pull_number" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4 #this step would go away
+      - uses: actions/checkout@v6             
+      - uses: actions/checkout@v6 #this step would go away
         with:
           path: action
           repository: layer5labs/meshmap-snapshot

--- a/.github/workflows/model-generator.yml
+++ b/.github/workflows/model-generator.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: "1.25"
 
       - name: Pull changes from remote
         run: git pull origin master
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: generate-logs
           path: ~/.meshery/logs/
@@ -59,7 +59,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_user_name: l5io
           commit_user_email: ci@layer5.io
@@ -70,7 +70,7 @@ jobs:
 
       - name: Send Email on Workflow Failure
         if: failure()
-        uses: dawidd6/action-send-mail@v3.7.1
+        uses: dawidd6/action-send-mail@v6
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -86,7 +86,7 @@ jobs:
 
       - name: Send Email on Registry Generate Error
         if: env.registry-generate-error == 'false' #Turn it back to true when we are good with all the errors.
-        uses: dawidd6/action-send-mail@v3.7.1
+        uses: dawidd6/action-send-mail@v6
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - 
         name: Checkout repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6
       - 
         name: Identify Release Values
         if: "${{ github.event.inputs.release-ver}} != 'v' }}"

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Download Site dir
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v11
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}
           workflow: build-and-preview-site.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Deploy to Netlify
         id: netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v3
         with:
           publish-dir: 'docs/_site'
           production-deploy: false

--- a/.github/workflows/redocly.yml
+++ b/.github/workflows/redocly.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
       - name: Setup go-swagger
@@ -34,7 +34,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs
           commit_user_name: l5io

--- a/.github/workflows/regal-lint.yml
+++ b/.github/workflows/regal-lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Regal
         uses: StyraInc/setup-regal@v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Drafting release
         id: release_drafter
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -29,7 +29,7 @@ jobs:
           run: git pull origin master
 
         - name: Commit
-          uses: stefanzweifel/git-auto-commit-action@v5
+          uses: stefanzweifel/git-auto-commit-action@v7
           with:
             file_pattern: docs
             commit_user_name: l5io

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -17,7 +17,7 @@ jobs:
           echo "STARS=$(curl --silent 'https://api.github.com/repos/${{ github.repository }}' -H 'Accept: application/vnd.github.preview' | jq '.stargazers_count')" >> $GITHUB_ENV
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -28,7 +28,7 @@ jobs:
         run: git pull origin master
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs server/helpers/
           commit_user_name: l5io

--- a/.github/workflows/test_adaptersv2.yaml
+++ b/.github/workflows/test_adaptersv2.yaml
@@ -66,7 +66,7 @@ jobs:
           echo "value=${USER_INPUT:-"meshery"}" >> $GITHUB_OUTPUT
       - name: Setting up minikube
         id: setk8s
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2
         with:
           minikube version: "v1.32.0"
           kubernetes version: "${{ matrix.k8s_version }}"
@@ -164,7 +164,7 @@ jobs:
           config='{"contexts":{"local":{"endpoint":'$svcip',"token":"default","platform":"kubernetes","adapters":[],"channel":"stable","version":"latest"}},"current-context":"local","tokens":[{"location":"auth.json","name":"default"}]}'
           echo $config  > ~/.meshery/config.yaml
       - name: Download patternfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: patternfile
       - name: Wait for Meshery pods to come up
@@ -260,7 +260,7 @@ jobs:
           echo $(jq '.metadata."meshery-server-version" |="'$MESHERY_VERSION'"' data.json ) > data.json
           echo "exitstatus=$exitstatus" >> $GITHUB_ENV
       - name: UploadResults
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.output_filename }}
           path: ./${{ inputs.output_filename }}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #47 

 **Changes made :**

- Updates the Go version used in this repository from 1.24 to 1.25.

- Updates GitHub Action version tags across the workflows to their latest stable releases.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 


