### PR TITLE
[CI] Deploy CNCF Playground from meshery/meshery with an evaluated tag

### DIFF
--- a/.github/workflows/build-and-release-stable.yml
+++ b/.github/workflows/build-and-release-stable.yml
@@ -193,7 +193,7 @@ jobs:
     name: Deploy CNCF Playground
     uses: meshery/meshery/.github/workflows/cncf-playground-deploy-meshery.yaml@master
     with:
-      image: layer5/meshery:playground-${GITHUB_REF/refs\/tags\//}
+      image: meshery/meshery:playground-${GITHUB_REF/refs\/tags\//}
     secrets: inherit
   email-on-failure:
     needs: [update-rest-api-docs, update-graphql-docs, build, ctlrelease, call-dde-release-workflow, call-helm-chart-releaser, email-meshery-release-notes-workflow, call-cncf-playground-rollout]

--- a/.github/workflows/build-and-release-stable.yml
+++ b/.github/workflows/build-and-release-stable.yml
@@ -193,7 +193,7 @@ jobs:
     name: Deploy CNCF Playground
     uses: meshery/meshery/.github/workflows/cncf-playground-deploy-meshery.yaml@master
     with:
-      image: meshery/meshery:playground-${GITHUB_REF/refs\/tags\//}
+      image: "meshery/meshery:playground-${{ github.ref_name }}"
     secrets: inherit
   email-on-failure:
     needs: [update-rest-api-docs, update-graphql-docs, build, ctlrelease, call-dde-release-workflow, call-helm-chart-releaser, email-meshery-release-notes-workflow, call-cncf-playground-rollout]


### PR DESCRIPTION
### Summary

One line in `.github/workflows/build-and-release-stable.yml` (line 196) had two
independent defects. This fixes both, and makes the line byte-for-byte identical to
`meshery/meshery`'s own call of the same reusable workflow.

```diff
-      image: layer5/meshery:playground-${GITHUB_REF/refs\/tags\//}
+      image: "meshery/meshery:playground-${{ github.ref_name }}"
```

**Defect 1 - wrong Docker Hub organization.** `layer5/meshery` stopped receiving playground
images fourteen months ago; publishing moved to `meshery/meshery` and this caller never
followed.

**Defect 2 - a tag expression GitHub never evaluates.** `${GITHUB_REF/refs\/tags\//}` is bash
parameter expansion. `with:` values are evaluated by the Actions expression engine, not by a
shell, so it was forwarded verbatim and the requested tag was the literal string
`playground-${GITHUB_REF/refs\/tags\//}`. Fixing only the organization would have left the
line still broken while looking repaired - the exact failure mode this PR exists to remove.

Note that the same `${GITHUB_REF/...}` expansion elsewhere in this file is **correct and
untouched**: those uses are inside `run:` shell steps, where a shell does evaluate them. Only
this one `with:` value was wrong.

Nothing else in the file changes. `git diff` against `master` is one file, `+1/-1`.

### What this deploy does today: nothing, and it never has

Stronger than "stale". Verified against the Actions API on 2026-08-05:

| Fact | `meshery-extensions/kubectl-kanvas-snapshot` |
|---|---|
| `v*` tags | **0** |
| Releases | **0** |
| Runs of `build-and-release-stable.yml` | **0** |

The workflow triggers on `push: tags: ["v*"]`. That has never fired here, so the release
workflow has never executed and `call-cncf-playground-rollout` has never run. Neither defect
above has ever been exercised - they are latent, not actively breaking a rollout.

Were a tag pushed, the job would still not deploy, for three independent reasons:

1. `call-cncf-playground-rollout` declares `needs: [build, deploy-delay]`, and `build` is
   guarded by `if: github.repository == 'meshery/meshery'`. A job whose dependency is skipped
   is itself skipped.
2. The reusable workflow's only job carries the same `if: github.repository == 'meshery/meshery'`
   guard. In a reusable workflow the `github` context is the **caller's**, so from this
   repository the condition is false.
3. Every other job in this file carries that guard too.

Points 1-3 are read from the workflow definitions and GitHub's documented reusable-workflow
context semantics; they are **not** demonstrated from an observed run, because no run of this
workflow exists in this repository to observe. What is directly observed is that the job
does execute in `meshery/meshery`, where the guard is true - e.g.
[run 30853447179](https://github.com/meshery/meshery/actions/runs/30853447179), job
"Deploy CNCF Playground / Update Meshery on CNCF playground": `success`.

**This PR does not touch that `if:` condition.** Removing it would activate a dormant deploy
from this repository, which is a product decision, not a repair. Flagged for maintainers.

### Docker Hub evidence

Re-verified directly against the registry API on 2026-08-05:

```
curl -s https://hub.docker.com/v2/repositories/layer5/meshery/tags/playground-latest/
curl -s https://hub.docker.com/v2/repositories/meshery/meshery/tags/playground-latest/
curl -s https://hub.docker.com/v2/repositories/layer5/meshery/tags/playground-v1.0.64/
curl -s https://hub.docker.com/v2/repositories/meshery/meshery/tags/playground-v1.0.64/
```

| Image | Result |
|---|---|
| `layer5/meshery:playground-latest` | last pushed **2025-05-30** |
| `meshery/meshery:playground-latest` | last pushed **2026-08-03** |
| `layer5/meshery:playground-v1.0.64` | **404 - does not exist** |
| `meshery/meshery:playground-v1.0.64` | exists, pushed 2026-08-03 |

The versioned tag pattern is absent from the old repository entirely, not just for one
version. All of `meshery/meshery`'s last five release tags - `v1.0.60`, `v1.0.61`, `v1.0.62`,
`v1.0.63`, `v1.0.64` - resolve under `meshery/meshery` and 404 under `layer5/meshery`.

The canonical Playground Deployment spec in `meshery/meshery`
(`install/playground/kubernetes/playground-deployment.yaml`) also pins
`meshery/meshery:playground-latest`.

### The shared workflow was checked

`cncf-playground-deploy-meshery.yaml` has **no** reference to the old repository and no
hard-coded fallback: its `image` input defaults to the bare string `playground-latest`, with
no namespace at all. Changing the callers is sufficient; no companion change is needed there.

### Related callers

An exhaustive sweep found five callers of this reusable workflow across `meshery` and
`meshery-extensions`. `meshery/pvtr` already uses the `meshery/meshery` organization but
still carries the unevaluated `${GITHUB_REF/...}` tag; it is outside this PR's repository and
is being raised separately. `layer5/kanvas` references elsewhere are intentional - Kanvas
stays on the `layer5` organization - and are untouched.

### On the red checks - both pre-existing, evidenced

This PR changes one line of YAML and touches no source code. Both failing checks fail for
causes that exist on `master` independent of this branch.

**`runner / eslint`** runs `cd ui && npm i eslint && npx eslint .`, and `ui/` does not exist
here - `GET /repos/meshery-extensions/kubectl-kanvas-snapshot/contents/ui?ref=master` returns
**404**. It dies at step 3, before ESLint is invoked:

```
/home/runner/work/_temp/....sh: line 1: cd: ui: No such file or directory
##[error]Process completed with exit code 1
```

| Branch | Date | Run |
|---|---|---|
| `fix/update-community-discussion-link` | 2026-07-18 | [29630316184](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/29630316184) |
| `feat/preview-retention` | 2026-07-03 | [28629683334](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/28629683334) |
| `copilot/governance-md-20260526-225850` | 2026-05-26 | [26480011245](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/26480011245) |
| `chore/remove-codecov` | 2026-01-12 | [20910845015](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/20910845015) |
| PR from a since-deleted fork | 2025-12-15 | [20240780497](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/20240780497) |

**`MeshMapScreenshot`** fails because the action looks for a Meshery design manifest this
repository does not have - `install/` itself is absent on `master` (**404**):

```
cat: install/deployment_yamls/k8s: No such file or directory
tail: cannot open 'install/deployment_yamls/k8s' for reading: No such file or directory
...
CypressError: `cy.visit()` failed trying to load:
```

| Branch | Date | Run |
|---|---|---|
| `fix/update-community-discussion-link` | 2026-07-18 | [29630315363](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/29630315363) |
| `feat/preview-retention` | 2026-07-03 | [28629682417](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/28629682417) |
| `fix/update-community-discussion-link` | 2026-06-30 | [28461362674](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/28461362674) |
| `update-maintainers.md` | 2026-05-29 | [26625102822](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/26625102822) |
| `patch-1` | 2026-01-21 | [21208336401](https://github.com/meshery-extensions/kubectl-kanvas-snapshot/actions/runs/21208336401) |

Both workflows were inherited from `meshery/meshery`, which has a `ui/` directory and that
manifest path. Fixing them is a separate change from a one-line image repair, so they are
flagged rather than bundled.
